### PR TITLE
Fixed the broken filter buttons.

### DIFF
--- a/script.js
+++ b/script.js
@@ -86,21 +86,32 @@ function handleTodoClick(event) {
     }
 }
 
-// BUG: Handle filter navigation - this function is broken!
+// Handle filter navigation
 function handleFilterClick(event) {
     if (event.target.classList.contains("filter-link")) {
         event.preventDefault();
         
-        // BUG: This code doesn't actually update the filter properly
+        // Update the currentFilter variable
         const href = event.target.getAttribute("href");
-        console.log("Clicked filter:", href); // This will show in console but won't work
         
-        // BUG: The active class management is broken
-        // It should remove active class from all links and add to clicked one
-        // But this code doesn't do that properly
+        if (href === "#/") {
+            currentFilter = "all";
+        }
+        if (href === "#/active") {
+            currentFilter = "active";
+        }
+        if (href === "#/completed") {
+            currentFilter = "completed";
+        }
         
-        // BUG: The currentFilter variable is never actually updated
-        // So the renderTodos() call below won't show filtered results
+        // Remove active class from all filter links
+        const allLinks = document.querySelectorAll(".filter-link");
+        allLinks[0].classList.remove("active");
+        allLinks[1].classList.remove("active");
+        allLinks[2].classList.remove("active");
+        
+        // Add active class to clicked element
+        event.target.classList.add("active");
         
         renderTodos();
     }

--- a/script.js
+++ b/script.js
@@ -96,19 +96,15 @@ function handleFilterClick(event) {
         
         if (href === "#/") {
             currentFilter = "all";
-        }
-        if (href === "#/active") {
+        } else if (href === "#/active") {
             currentFilter = "active";
-        }
-        if (href === "#/completed") {
+        } else if (href === "#/completed") {
             currentFilter = "completed";
         }
         
         // Remove active class from all filter links
         const allLinks = document.querySelectorAll(".filter-link");
-        allLinks[0].classList.remove("active");
-        allLinks[1].classList.remove("active");
-        allLinks[2].classList.remove("active");
+        allLinks.forEach(link => link.classList.remove("active"));
         
         // Add active class to clicked element
         event.target.classList.add("active");


### PR DESCRIPTION
Fixed the broken filter navigation buttons. Now users can properly filter todos by All/Active/Completed status.

**Changes Made:**
- Updated `handleFilterClick` function to properly set `currentFilter` variable
- Added logic to manage active CSS class on filter buttons  
- Fixed filtering so it actually works now

**Testing:**
- [x] All filter shows all todos
- [x] Active filter shows only incomplete todos
- [x] Completed filter shows only completed todos
- [x] Active button styling updates correctly

**Related issues:**
- #1 